### PR TITLE
Remove broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
 # Lokalise apps repository
 
 This repository contains the source code for demo Lokalise apps and helpful resources to build your own apps for Lokalise.
-
-## Examples apps
-
-1. [Upload i18n files via node api](/examples/upload-i18n-files-node-api/)


### PR DESCRIPTION
@anilkk The link to the example that was mentioned on the repo README.md seems to be broken. I suggest we delete it and keep this is a light page, so we don't need to maintain it every time we add a new app. Thoughts?